### PR TITLE
Add to and from operations

### DIFF
--- a/include/Galois/GaloisOps.td
+++ b/include/Galois/GaloisOps.td
@@ -50,8 +50,26 @@ def Galois_ConstantOp : Galois_Op<"constant", [Pure]> {
     }];
 
     let arguments = (ins Galois_GF8ConstantAttr:$value);
-    let results = (outs Galois_GF8Type:$res);
+    let results = (outs I32:$res);
 
     let assemblyFormat = " $value attr-dict `:` type($res)";
+}
+
+def Galois_ToIntegerOp : Galois_Op<"to_integer", [Pure]> {
+    let summary = "Converts GF(2^8) type to i32.";
+    let description = [{}];
+    let arguments = (ins Galois_GF8Type:$input);
+    let results = (outs I32:$res);
+    let hasVerifier = 1;
+    let assemblyFormat = "$input attr-dict `:` type($res)";
+}
+
+def Galois_FromIntegerOp : Galois_Op<"from_integer", [Pure]> {
+    let summary = "Converts i32 to GF(2^8).";
+    let description = [{}];
+    let arguments = (ins I32:$input);
+    let results = (outs Galois_GF8Type:$res);
+    let hasVerifier = 1;
+    let assemblyFormat = "$input attr-dict `:` type($res)";
 }
 #endif // GALOIS_OPS

--- a/test/Galois/galois-from-and-to.mlir
+++ b/test/Galois/galois-from-and-to.mlir
@@ -1,0 +1,43 @@
+module {
+  // ConstantOp test
+  %c = galois.constant <42> : i32
+
+  // FromIntegerOp test - fixed syntax
+  %gf8_val = galois.from_integer %c : !galois.gf8
+
+  // ToIntegerOp test - fixed syntax
+  %i32_val = galois.to_integer %gf8_val : i32
+}
+
+module {
+  // ConstantOp test
+  %c42 = arith.constant 42 : i32
+
+  // FromIntegerOp test
+  %gf8_val = galois.from_integer %c42 : !galois.gf8
+
+  // ToIntegerOp test
+  %i32_val = galois.to_integer %gf8_val : i32
+}
+
+
+//Should fail
+module {
+  // ConstantOp test
+  %c42 = arith.constant 256 : i32
+
+  // FromIntegerOp test
+  %gf8_val = galois.to_integer %c42 : i32
+
+}
+
+
+//Should fail
+module {
+  // ConstantOp test
+  %c42 = arith.constant 256 : i32
+
+  // FromIntegerOp test
+  %gf8_val = galois.from_integer %c42 : !galois.gf8
+
+}


### PR DESCRIPTION
This PR adds operations for converting to and from the `i32` type. These are just being made now in case they  might be needed later. The custom type and attribute created earlier might not be needed, since a lot of the work from here on out will be done using 32 bit integers and masking