### PR TITLE
Matmul cleanup

### DIFF
--- a/include/Galois/GaloisOps.td
+++ b/include/Galois/GaloisOps.td
@@ -186,26 +186,31 @@ def Galois_RSDecodeOp : Galois_Op<"rs_decode", [Pure]> {
     let assemblyFormat = " $codeword attr-dict `:` type($codeword) `->`type($message)";
 }
 
-def Galois_MatMulOp : Galois_Op<"matmul", [Pure, AttrSizedOperandSegments]> {
-    let summary  = "Matrix multiplication in GF(2^8)";
+def Galois_MatMulOp : Galois_Op<"matmul", [AttrSizedOperandSegments]> {
+    let summary = "Matrix multiplication in GF(2^8)";
     let description = [{
         Given A ∈ GF(2^8)^(M×K) and B ∈ GF(2^8)^(K×N), computes
-        C = A · B   with C ∈ GF(2^8)^(M×N),
-        interpreting all inputs/results as flattened row‑major lists.
+        C = A · B   with C stored in the provided output MemRef.
+        Inputs are flattened row-major lists.
     }];
 
-    // Two variadic input lists (flattened A and B), one variadic result list.
     let arguments = (ins
-        Variadic<I32>:$lhs,
-        Variadic<I32>:$rhs,
+        Variadic<AnyTypeOf<[I32, MemRefOf<[I32]>]>>:$lhs,
+        Variadic<AnyTypeOf<[I32, MemRefOf<[I32]>]>>:$rhs,
+        MemRefOf<[I32]>:$output,
         I32Attr:$rowsA,
         I32Attr:$colsA,
         I32Attr:$colsB
-        );
+    );
 
-    let results = (outs Variadic<I32>:$res);
+    let assemblyFormat = [{
+        `[` $lhs `:` type($lhs) `]`
+        `by`
+        `[` $rhs `:` type($rhs) `]`
+        `into` $output attr-dict `:` type($output)
+    }];
+
     let hasVerifier = 1;
-    let assemblyFormat = [{ `[` $lhs `]` `by` `[` $rhs `]` attr-dict `:` functional-type(operands, results) }];
 }
 
 def Galois_LagrangeInterpOp : Galois_Op<"lagrange_interp", [Pure]> {
@@ -222,17 +227,31 @@ def Galois_LagrangeInterpOp : Galois_Op<"lagrange_interp", [Pure]> {
     let assemblyFormat = "$coords attr-dict `:` type($coords) `->` type($coeffs)";
 }
 
-def Galois_MixColumnsOp : Galois_Op<"mix_columns", [Pure]> {
+// def Galois_MixColumnsOp : Galois_Op<"mix_columns", [Pure]> {
+//     let summary = "AES MixColumns on a single 4-byte column in GF(2^8)";
+//     let description = [{
+//         Given a column [s0,s1,s2,s3], computes M·[s0,s1,s2,s3] where M is
+//         the fixed AES MixColumns matrix over GF(2^8), using the generic `matmul` op.
+//     }];
+
+//     let arguments = (ins Variadic<I32>:$col);
+//     let results = (outs Variadic<I32>:$result);
+//     let hasVerifier = 1;
+//     let assemblyFormat = "$col attr-dict `:` functional-type($col, $result)";
+// }
+
+def Galois_MixColumnsOp : Galois_Op<"mix_columns", []> {
     let summary = "AES MixColumns on a single 4-byte column in GF(2^8)";
     let description = [{
-        Given a column [s0,s1,s2,s3], computes M·[s0,s1,s2,s3] where M is
-        the fixed AES MixColumns matrix over GF(2^8), using the generic `matmul` op.
+        Given a column in memory (4 bytes), performs MixColumns transformation
+        and stores the result in the output column memref.
     }];
 
-    let arguments = (ins Variadic<I32>:$col);
-    let results = (outs Variadic<I32>:$result);
-    let hasVerifier = 1;
-    let assemblyFormat = "$col attr-dict `:` functional-type($col, $result)";
+    let arguments = (ins
+        MemRefOf<[I32]>:$col,       // Input column (4 bytes)
+        MemRefOf<[I32]>:$out        // Output column (4 bytes)
+    );
+    let assemblyFormat = "$col `into` $out attr-dict `:` type($col) `,` type($out)";
 }
 
 def Galois_HashOp : Galois_Op<"hash", [Pure]> {

--- a/lib/Galois/GaloisOps.cpp
+++ b/lib/Galois/GaloisOps.cpp
@@ -278,40 +278,58 @@ LogicalResult MatMulOp::verify() {
   if (M <= 0 || K <= 0 || N <= 0)
     return emitOpError("all matrix dimensions must be positive");
 
-  // Check lhs size
-  if (static_cast<int64_t>(lhsVals.size()) != M * K)
-    return emitOpError("lhs operand size does not match rowsA × colsA");
+  // --- LHS check ---
+  bool lhsIsMemref = (lhsVals.size() == 1) && mlir::isa<MemRefType>(lhsVals[0].getType());
+  if (!lhsIsMemref) {
+    if ((int64_t)lhsVals.size() != M * K)
+      return emitOpError("lhs operand size does not match rowsA × colsA");
+  } else {
+    auto lhsType = mlir::cast<MemRefType>(lhsVals[0].getType());
+    if (lhsType.hasStaticShape() && lhsType.getNumElements() < M * K)
+      return emitOpError("lhs memref too small for rowsA × colsA");
+  }
 
-  // Check rhs size
-  if (static_cast<int64_t>(rhsVals.size()) != K * N)
-    return emitOpError("rhs operand size does not match colsA × colsB");
+  // --- RHS check ---
+  bool rhsIsMemref = (rhsVals.size() == 1) && mlir::isa<MemRefType>(rhsVals[0].getType());
+  if (!rhsIsMemref) {
+    if ((int64_t)rhsVals.size() != K * N)
+      return emitOpError("rhs operand size does not match colsA × colsB");
+  } else {
+    auto rhsType = mlir::cast<MemRefType>(rhsVals[0].getType());
+    if (rhsType.hasStaticShape() && rhsType.getNumElements() < K * N)
+      return emitOpError("rhs memref too small for colsA × colsB");
+  }
 
-  // Check output memref shape (if statically known)
+  // --- Output memref check ---
   if (outputType.hasStaticShape()) {
     int64_t outSize = outputType.getNumElements();
     if (outSize < M * N)
       return emitOpError("output memref too small for result matrix");
   }
 
-  // Check output type is memref<i32>
   if (!outputType.getElementType().isInteger(32))
     return emitOpError("output must be memref of i32");
 
-  // Check value range (if constant)
-  for (auto val : lhsVals)
-    if (auto cst = val.getDefiningOp<arith::ConstantOp>())
-      if (auto intVal = mlir::dyn_cast<IntegerAttr>(cst.getValue()))
-        if (intVal.getInt() < 0 || intVal.getInt() > 255)
-          return emitOpError("lhs values must be in [0, 255]");
+  // --- Value range check only for constant scalars ---
+  if (!lhsIsMemref) {
+    for (auto val : lhsVals)
+      if (auto cst = val.getDefiningOp<arith::ConstantOp>())
+        if (auto intVal = mlir::dyn_cast<IntegerAttr>(cst.getValue()))
+          if (intVal.getInt() < 0 || intVal.getInt() > 255)
+            return emitOpError("lhs values must be in [0, 255]");
+  }
 
-  for (auto val : rhsVals)
-    if (auto cst = val.getDefiningOp<arith::ConstantOp>())
-      if (auto intVal = mlir::dyn_cast<IntegerAttr>(cst.getValue()))
-        if (intVal.getInt() < 0 || intVal.getInt() > 255)
-          return emitOpError("rhs values must be in [0, 255]");
+  if (!rhsIsMemref) {
+    for (auto val : rhsVals)
+      if (auto cst = val.getDefiningOp<arith::ConstantOp>())
+        if (auto intVal = mlir::dyn_cast<IntegerAttr>(cst.getValue()))
+          if (intVal.getInt() < 0 || intVal.getInt() > 255)
+            return emitOpError("rhs values must be in [0, 255]");
+  }
 
   return success();
 }
+
 
 
 
@@ -350,25 +368,25 @@ LogicalResult MatMulOp::verify() {
 // MixColumnsOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult MixColumnsOp::verify() {
-    auto col = getCol();  // ValueRange of inputs
-    // Must have exactly 4 inputs and 4 results.
-    if (col.size() != 4)
-      return emitOpError("expects exactly 4 input bytes, got ") << col.size();
-    if (getNumResults() != 4)
-      return emitOpError("expects exactly 4 result bytes, got ") << getNumResults();
+// LogicalResult MixColumnsOp::verify() {
+//     auto col = getCol();  // ValueRange of inputs
+//     // Must have exactly 4 inputs and 4 results.
+//     if (col.size() != 4)
+//       return emitOpError("expects exactly 4 input bytes, got ") << col.size();
+//     if (getNumResults() != 4)
+//       return emitOpError("expects exactly 4 result bytes, got ") << getNumResults();
   
-    // Ensure any constant inputs lie in [0,255].
-    for (unsigned i = 0; i < 4; ++i) {
-      if (auto cst = col[i].getDefiningOp<arith::ConstantIntOp>()) {
-        int64_t v = cst.value();
-        if (v < 0 || v > 255)
-          return emitOpError("input #") << i
-                 << " out of GF(2^8) range [0,255]: " << v;
-      }
-    }
-    return success();
-  }
+//     // // Ensure any constant inputs lie in [0,255].
+//     // for (unsigned i = 0; i < 4; ++i) {
+//     //   if (auto cst = col[i].getDefiningOp<arith::ConstantIntOp>()) {
+//     //     int64_t v = cst.value();
+//     //     if (v < 0 || v > 255)
+//     //       return emitOpError("input #") << i
+//     //              << " out of GF(2^8) range [0,255]: " << v;
+//     //   }
+//     // }
+//     return success();
+//   }
 
 
 //===----------------------------------------------------------------------===//

--- a/test/Galois/matmul.mlir
+++ b/test/Galois/matmul.mlir
@@ -1,20 +1,112 @@
+// module {
+//   func.func @main() -> i32 {
+  
+//     %a0 = arith.constant 1 : i32
+//     %a1 = arith.constant 2 : i32
+//     %a2 = arith.constant 3 : i32
+//     %a3 = arith.constant 4 : i32
+
+//     %b0 = arith.constant 5 : i32
+//     %b1 = arith.constant 6 : i32
+//     %b2 = arith.constant 7 : i32
+//     %b3 = arith.constant 8 : i32
+
+//     // Allocate output buffer
+//     %output = memref.alloc() : memref<4xi32>
+
+//     %d0 = arith.constant 0 : index
+//     %d1 = arith.constant 1 : index
+//     %d2 = arith.constant 2 : index
+//     %d3 = arith.constant 3 : index
+//     %zero = arith.constant 0 : i32
+
+//     memref.store %zero, %output[%d0] : memref<4xi32>
+//     memref.store %zero, %output[%d1] : memref<4xi32>
+//     memref.store %zero, %output[%d2] : memref<4xi32>
+//     memref.store %zero, %output[%d3] : memref<4xi32>
+
+
+//     // Call matmul
+//     galois.matmul 
+//     [%a0, %a1, %a2, %a3 : i32, i32, i32, i32] 
+//     by 
+//     [%b0, %b1, %b2, %b3 : i32, i32, i32, i32] 
+//     into %output 
+//     {rowsA = 2 : i32, colsA = 2 : i32, colsB = 2 : i32}
+//     : memref<4xi32>
+
+//     // Constants for indices
+//     %c0 = arith.constant 0 : index
+//     %c1 = arith.constant 1 : index
+//     %c2 = arith.constant 2 : index
+//     %c3 = arith.constant 3 : index
+
+//     // Load output scalars
+//     %r0 = memref.load %output[%c0] : memref<4xi32>
+//     %r1 = memref.load %output[%c1] : memref<4xi32>
+//     %r2 = memref.load %output[%c2] : memref<4xi32>
+//     %r3 = memref.load %output[%c3] : memref<4xi32>
+
+
+//     // func.return %r0, %r1, %r2, %r3 : i32, i32, i32, i32
+//     %out = arith.xori %r0, %r1 : i32
+//     %out2 = arith.xori %r2, %r3 : i32
+//     %final = arith.xori %out, %out2 : i32
+//     return %final : i32 //return single result for flat file testing in gem5 
+
+//   }
+// }
+
 module {
-  func.func @testMatMul() -> (i32, i32, i32, i32) {
-    // A = [1, 2; 3, 4], B = [5, 6; 7, 8]
-    %a0 = arith.constant 1 : i32
-    %a1 = arith.constant 2 : i32
-    %a2 = arith.constant 3 : i32
-    %a3 = arith.constant 4 : i32
-    %b0 = arith.constant 5 : i32
-    %b1 = arith.constant 6 : i32
-    %b2 = arith.constant 7 : i32
-    %b3 = arith.constant 8 : i32
+  func.func @main() -> i32 {
+    %zero = arith.constant 0 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c100 = arith.constant 100 : index
+    %c10 = arith.constant 10 : index
 
-    %r0, %r1, %r2, %r3 = galois.matmul 
-      [%a0, %a1, %a2, %a3] by [%b0, %b1, %b2, %b3] 
-      {rowsA = 2 : i32, colsA = 2 : i32, colsB = 2 : i32} 
-      : (i32, i32, i32, i32, i32, i32, i32, i32) -> (i32, i32, i32, i32)
+    // Allocate A, B, C on the stack
+    %A = memref.alloca() : memref<100xi32>
+    %B = memref.alloca() : memref<100xi32>
+    %C = memref.alloca() : memref<100xi32>
 
-    return %r0, %r1, %r2, %r3 : i32, i32, i32, i32
+    %one = arith.constant 1 : i32
+    scf.for %i = %c0 to %c100 step %c1 {
+      %val = arith.index_cast %i : index to i32
+      %val_plus_one = arith.addi %val, %one : i32
+      memref.store %val_plus_one, %A[%i] : memref<100xi32>
+    }
+
+    %two = arith.constant 2 : i32
+    scf.for %i = %c0 to %c100 step %c1 {
+      %val = arith.index_cast %i : index to i32
+      %val_plus_one = arith.addi %val, %one : i32
+      %double = arith.muli %val_plus_one, %two : i32
+      memref.store %double, %B[%i] : memref<100xi32>
+    }
+
+
+    // Zero initialize C[i]
+    scf.for %i = %c0 to %c100 step %c1 {
+      memref.store %zero, %C[%i] : memref<100xi32>
+    }
+
+    // Call galois.matmul
+    galois.matmul
+      [%A : memref<100xi32>]
+      by [%B : memref<100xi32>]
+      into %C
+      {rowsA = 10 : i32, colsA = 10 : i32, colsB = 10 : i32}
+      : memref<100xi32>
+
+    // XOR accumulate all values in C
+    %acc0 = arith.constant 0 : i32
+    %result = scf.for %i = %c0 to %c100 step %c1 iter_args(%acc = %acc0) -> i32 {
+      %val = memref.load %C[%i] : memref<100xi32>
+      %next = arith.xori %acc, %val : i32
+      scf.yield %next : i32
+    }
+
+    return %result : i32
   }
 }

--- a/test/Galois/mixcolumns.mlir
+++ b/test/Galois/mixcolumns.mlir
@@ -1,13 +1,151 @@
+// module {
+//   func.func @main() -> (i32) {
+//     // 1) Allocate memory for input and output columns
+//     %col = memref.alloc() : memref<4xi32>
+//     %out = memref.alloc() : memref<4xi32>
+
+//     // 2) Constants for the column
+//     %a = arith.constant 0xd4 : i32
+//     %b = arith.constant 0xbf : i32
+//     %c = arith.constant 0x5d : i32
+//     %d = arith.constant 0x30 : i32
+
+//     // 3) Store column values in the input memref
+//     %c0 = arith.constant 0 : index
+//     %c1 = arith.constant 1 : index
+//     %c2 = arith.constant 2 : index
+//     %c3 = arith.constant 3 : index
+//     memref.store %a, %col[%c0] : memref<4xi32>
+//     memref.store %b, %col[%c1] : memref<4xi32>
+//     memref.store %c, %col[%c2] : memref<4xi32>
+//     memref.store %d, %col[%c3] : memref<4xi32>
+
+//     // 4) Call MixColumns (memory-based)
+//     galois.mix_columns %col into %out
+//       : memref<4xi32>, memref<4xi32>
+
+//     // 5) Load results from the output memref
+//     %r0 = memref.load %out[%c0] : memref<4xi32>
+//     %r1 = memref.load %out[%c1] : memref<4xi32>
+//     %r2 = memref.load %out[%c2] : memref<4xi32>
+//     %r3 = memref.load %out[%c3] : memref<4xi32>
+
+//     // 6) Return results
+//     // func.return %r0, %r1, %r2, %r3 : i32, i32, i32, i32
+//     %out1 = arith.xori %r0, %r1 : i32
+//     %out2 = arith.xori %r2, %r3 : i32
+//     %final = arith.xori %out1, %out2 : i32
+//     func.return %final : i32 //return single result for flat file testing in gem5 
+//   }
+// }
+
 module {
-  func.func @testMixColumns() -> (i32, i32, i32, i32) {
-    %a = arith.constant 0xd4 : i32
-    %b = arith.constant 0xbf : i32
-    %c = arith.constant 0x5d : i32
-    %d = arith.constant 0x30 : i32
+  func.func @main() -> (i32) {
+    // 1) Allocate memory for input and output states
+    %state = memref.alloca() : memref<16xi32>
+    %out   = memref.alloca() : memref<16xi32>
 
-    %r0, %r1, %r2, %r3 = galois.mix_columns %a, %b, %c, %d
-      : (i32, i32, i32, i32) -> (i32, i32, i32, i32)
+    // 2) Constants for the state (row-major 4x4)
+    %c0  = arith.constant 0xd4 : i32
+    %c1  = arith.constant 0xbf : i32
+    %c2  = arith.constant 0x5d : i32
+    %c3  = arith.constant 0x30 : i32
+    %c4  = arith.constant 0xe0 : i32
+    %c5  = arith.constant 0xb4 : i32
+    %c6  = arith.constant 0x52 : i32
+    %c7  = arith.constant 0xae : i32
+    %c8  = arith.constant 0xb8 : i32
+    %c9  = arith.constant 0x41 : i32
+    %c10 = arith.constant 0x11 : i32
+    %c11 = arith.constant 0xf1 : i32
+    %c12 = arith.constant 0x1e : i32
+    %c13 = arith.constant 0x27 : i32
+    %c14 = arith.constant 0x98 : i32
+    %c15 = arith.constant 0xe5 : i32
 
-    return %r0, %r1, %r2, %r3 : i32, i32, i32, i32
+    // 3) Store constants into state
+    %i0  = arith.constant 0  : index
+    %i1  = arith.constant 1  : index
+    %i2  = arith.constant 2  : index
+    %i3  = arith.constant 3  : index
+    %i4  = arith.constant 4  : index
+    %i5  = arith.constant 5  : index
+    %i6  = arith.constant 6  : index
+    %i7  = arith.constant 7  : index
+    %i8  = arith.constant 8  : index
+    %i9  = arith.constant 9  : index
+    %i10 = arith.constant 10 : index
+    %i11 = arith.constant 11 : index
+    %i12 = arith.constant 12 : index
+    %i13 = arith.constant 13 : index
+    %i14 = arith.constant 14 : index
+    %i15 = arith.constant 15 : index
+
+    memref.store %c0,  %state[%i0]  : memref<16xi32>
+    memref.store %c1,  %state[%i1]  : memref<16xi32>
+    memref.store %c2,  %state[%i2]  : memref<16xi32>
+    memref.store %c3,  %state[%i3]  : memref<16xi32>
+    memref.store %c4,  %state[%i4]  : memref<16xi32>
+    memref.store %c5,  %state[%i5]  : memref<16xi32>
+    memref.store %c6,  %state[%i6]  : memref<16xi32>
+    memref.store %c7,  %state[%i7]  : memref<16xi32>
+    memref.store %c8,  %state[%i8]  : memref<16xi32>
+    memref.store %c9,  %state[%i9]  : memref<16xi32>
+    memref.store %c10, %state[%i10] : memref<16xi32>
+    memref.store %c11, %state[%i11] : memref<16xi32>
+    memref.store %c12, %state[%i12] : memref<16xi32>
+    memref.store %c13, %state[%i13] : memref<16xi32>
+    memref.store %c14, %state[%i14] : memref<16xi32>
+    memref.store %c15, %state[%i15] : memref<16xi32>
+
+    // 4) Loop through the 4 columns (each column has 4 rows)
+    %c4_idx = arith.constant 4 : index
+    scf.for %col = %i0 to %c4_idx step %i1 {
+      %col_mem = memref.alloca() : memref<4xi32>
+      %out_col = memref.alloca() : memref<4xi32>
+
+      %base = arith.muli %col, %c4_idx : index
+      %row0 = arith.addi %base, %i0 : index
+      %row1 = arith.addi %base, %i1 : index
+      %row2 = arith.addi %base, %i2 : index
+      %row3 = arith.addi %base, %i3 : index
+
+      %v0 = memref.load %state[%row0] : memref<16xi32>
+      %v1 = memref.load %state[%row1] : memref<16xi32>
+      %v2 = memref.load %state[%row2] : memref<16xi32>
+      %v3 = memref.load %state[%row3] : memref<16xi32>
+
+      memref.store %v0, %col_mem[%i0] : memref<4xi32>
+      memref.store %v1, %col_mem[%i1] : memref<4xi32>
+      memref.store %v2, %col_mem[%i2] : memref<4xi32>
+      memref.store %v3, %col_mem[%i3] : memref<4xi32>
+
+      galois.mix_columns %col_mem into %out_col
+        : memref<4xi32>, memref<4xi32>
+
+      %o0 = memref.load %out_col[%i0] : memref<4xi32>
+      %o1 = memref.load %out_col[%i1] : memref<4xi32>
+      %o2 = memref.load %out_col[%i2] : memref<4xi32>
+      %o3 = memref.load %out_col[%i3] : memref<4xi32>
+
+      memref.store %o0, %out[%row0] : memref<16xi32>
+      memref.store %o1, %out[%row1] : memref<16xi32>
+      memref.store %o2, %out[%row2] : memref<16xi32>
+      memref.store %o3, %out[%row3] : memref<16xi32>
+
+      // memref.dealloc %col_mem : memref<4xi32>
+      // memref.dealloc %out_col : memref<4xi32>
+    }
+
+    // 5) XOR reduction using loop-carried value
+    %r16 = arith.constant 16 : index
+    %zero = arith.constant 0 : i32
+    %final = scf.for %j = %i0 to %r16 step %i1 iter_args(%acc = %zero) -> i32 {
+      %val = memref.load %out[%j] : memref<16xi32>
+      %new_acc = arith.xori %acc, %val : i32
+      scf.yield %new_acc : i32
+    }
+
+    func.return %final : i32
   }
 }


### PR DESCRIPTION
This PR introduces the following:
1. Changes to the macro name and removal of unwanted globals for the header file  `GaloisHelpers.h`.
2. Changes to the ODS definitions of `MatMulOp` and `MixColumnsOp` to accept `MemRef` inputs.
3. Changes to the verifiers of the above operations to acccommodate memref inputs.
4. Switch to using SCF for loops in `MatMulOp`.
5. Addition of a helper to materialize memrefs in matrix multiplication.
6. Changes to test files for larger workloads.